### PR TITLE
Add etag support to balde

### DIFF
--- a/doc/00_index.md
+++ b/doc/00_index.md
@@ -7,7 +7,7 @@ It is designed to be fast, simple, and memory efficient. Most of its architectur
 
 As a micro-framework, it just does the basic and tries to do it quite well. It will not stay on your way and will let you do almost anything the way you want, but you may have to do some extra work to get complex stuff done.
 
-*balde* uses GLib, the low-level system libraries developed by GNOME project. Some knowledge of the library and its usege is required. Some knowledge of other micro-frameworks, like [Flask](http://flask.pocoo.org/) may be useful as well.
+*balde* uses GLib, the low-level system libraries developed by GNOME project. Some knowledge of the library and its usage is required. Some knowledge of other micro-frameworks, like [Flask](http://flask.pocoo.org/) may be useful as well.
 
 *balde* is free software, released under the LGPL2 license.
 

--- a/src/balde.h
+++ b/src/balde.h
@@ -442,8 +442,8 @@ void balde_response_set_header(balde_response_t *response, const gchar *name,
 /**
  * Get a response header.
  */
-GSList*
-balde_response_get_header(balde_response_t *response, const gchar *name);
+GSList* balde_response_get_header(balde_response_t *response,
+    const gchar *name);
 
 
 /**

--- a/src/balde.h
+++ b/src/balde.h
@@ -439,6 +439,12 @@ void balde_app_run(balde_app_t *app, gint argc, gchar **argv);
 void balde_response_set_header(balde_response_t *response, const gchar *name,
     const gchar *value);
 
+/**
+ * Get a response header.
+ */
+GSList*
+balde_response_get_header(balde_response_t *response, const gchar *name);
+
 
 /**
  * Appends a nul-terminated string to the response body.

--- a/src/balde.h
+++ b/src/balde.h
@@ -463,6 +463,13 @@ void balde_response_append_body_len(balde_response_t *response,
 
 
 /**
+ * Truncate response's body.
+ *
+ */
+void balde_response_truncate_body(balde_response_t *response);
+
+
+/**
  * Initialize a response context.
  *
  * The nul-terminated string passed as argument is used to initialize the

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -15,6 +15,7 @@
 #include "balde.h"
 #include "app.h"
 #include "cgi.h"
+#include "utils.h"
 
 
 guint64
@@ -50,7 +51,8 @@ GHashTable*
 balde_cgi_request_headers(void)
 {
     gchar **headers = g_listenv();
-    GHashTable *rv = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+    GHashTable *rv = g_hash_table_new_full(g_str_hash, balde_header_compare,
+        g_free, g_free);
     for (guint i = 0; headers[i] != NULL; i++) {
         gchar *key = balde_parse_header_name_from_envvar(headers[i]);
         if (key != NULL)

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -20,6 +20,7 @@
 #include "httpd.h"
 #include "requests.h"
 #include "responses.h"
+#include "utils.h"
 
 
 balde_httpd_parser_data_t*
@@ -41,7 +42,8 @@ balde_httpd_parse_request(balde_app_t *app, GInputStream *istream)
     gchar *key = NULL;
     gchar *value = NULL;
     GString *body = NULL;
-    GHashTable *headers = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+    GHashTable *headers = g_hash_table_new_full(g_str_hash,
+        balde_header_compare, g_free, g_free);
     gchar **pieces = g_strsplit(line, " ", 3);
     g_free(line);
 

--- a/src/requests.h
+++ b/src/requests.h
@@ -13,6 +13,8 @@
 #include "balde.h"
 #include "sessions.h"
 
+static const gchar *BALDE_REQUEST_ETAG_HEADER = "If-None-Match";
+
 typedef struct {
     gchar *request_method;
     gchar *server_name;

--- a/src/resources.c
+++ b/src/resources.c
@@ -147,18 +147,12 @@ balde_make_response_from_static_resource(balde_app_t *app, balde_request_t *requ
             g_date_time_unref(expires_dt);
             balde_response_set_header(response, "Expires", expires);
             g_free(expires);
+            balde_response_append_body_len(response, resource->content->str,
+                resource->content->len);
 
-            gchar *etag = g_strdup_printf("\"balde-%s-%s\"", resource->hash_name,
-                resource->hash_content);
-            balde_response_set_header(response, "Etag", etag);
-            const gchar *if_none_match = balde_request_get_header(request,
-                "If-None-Match");
-            if (if_none_match != NULL && (g_strcmp0(if_none_match, etag) == 0))
-                response->status_code = 304;
-            else
-                balde_response_append_body_len(response, resource->content->str,
-                    resource->content->len);
-            g_free(etag);
+            balde_response_add_etag_header(response, TRUE);
+            balde_response_etag_matching(request, response);
+
             if (resource->type != NULL)
                 balde_response_set_header(response, "Content-Type", resource->type);
             return response;

--- a/src/responses.c
+++ b/src/responses.c
@@ -228,6 +228,13 @@ balde_header_render(const gchar *key, GSList *value, GString *str)
 }
 
 
+gchar*
+balde_response_generate_etag(balde_response_t *response)
+{
+    return g_compute_checksum_for_string(G_CHECKSUM_MD5, response->priv->body->str, response->priv->body->len);
+}
+
+
 GString*
 balde_response_render(balde_response_t *response, const gboolean with_body)
 {

--- a/src/responses.c
+++ b/src/responses.c
@@ -18,6 +18,7 @@
 #include "exceptions.h"
 #include "routing.h"
 #include "responses.h"
+#include "utils.h"
 
 
 BALDE_API void
@@ -94,8 +95,8 @@ balde_make_response_from_gstring(GString *content)
     balde_response_t *response = g_new(balde_response_t, 1);
     response->priv = g_new(struct _balde_response_private_t, 1);
     response->status_code = 200;
-    response->priv->headers = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
-        balde_response_headers_free);
+    response->priv->headers = g_hash_table_new_full(g_str_hash,
+        balde_header_compare, g_free, balde_response_headers_free);
     response->priv->template_ctx = g_hash_table_new_full(g_str_hash, g_str_equal,
         g_free, g_free);
     response->priv->body = content;
@@ -269,13 +270,13 @@ void
 balde_response_add_etag_header(balde_response_t * response, gboolean weak)
 {
     GString *header_contents = g_string_new("");
-    if (weak) {
+    if (weak)
         g_string_append(header_contents, "W/");
-    }
     g_string_append(header_contents, "\"");
     gchar *hash = balde_response_generate_etag(response);
     g_string_append(header_contents, hash);
     g_string_append(header_contents, "\"");
+    /* The etag will always be replaced. */
     balde_response_remove_header(response, BALDE_RESPONSE_ETAG_HEADER);
     balde_response_set_header(response, BALDE_RESPONSE_ETAG_HEADER, header_contents->str);
 

--- a/src/responses.c
+++ b/src/responses.c
@@ -260,25 +260,34 @@ balde_header_render(const gchar *key, GSList *value, GString *str)
 
 
 gchar*
-balde_response_generate_etag(balde_response_t *response)
+balde_response_generate_etag(balde_response_t *response, gboolean weak)
 {
-    return g_compute_checksum_for_string(G_CHECKSUM_MD5, response->priv->body->str, response->priv->body->len);
+    GString *header_contents = g_string_new("");
+    gchar *hash;
+    if (weak)
+        g_string_append(header_contents, "W/");
+    g_string_append(header_contents, "\"");
+
+    g_string_append(header_contents,
+        g_compute_checksum_for_string(G_CHECKSUM_MD5,
+        response->priv->body->str, response->priv->body->len)
+    );
+
+    g_string_append(header_contents, "\"");
+    hash = header_contents->str;
+    g_string_free(header_contents, FALSE);
+    return hash;
 }
 
 
 void
 balde_response_add_etag_header(balde_response_t * response, gboolean weak)
 {
-    GString *header_contents = g_string_new("");
-    if (weak)
-        g_string_append(header_contents, "W/");
-    g_string_append(header_contents, "\"");
-    gchar *hash = balde_response_generate_etag(response);
-    g_string_append(header_contents, hash);
-    g_string_append(header_contents, "\"");
+    gchar *hash = balde_response_generate_etag(response, weak);
     /* The etag will always be replaced. */
     balde_response_remove_header(response, BALDE_RESPONSE_ETAG_HEADER);
-    balde_response_set_header(response, BALDE_RESPONSE_ETAG_HEADER, header_contents->str);
+    balde_response_set_header(response, BALDE_RESPONSE_ETAG_HEADER, hash);
+}
 
     g_string_free(header_contents, TRUE);
     g_free(hash);

--- a/src/responses.c
+++ b/src/responses.c
@@ -42,6 +42,7 @@ balde_response_remove_header(balde_response_t *response, const gchar *name)
     gboolean removed;
     gchar *l_name = g_ascii_strdown(name, -1);
     removed = g_hash_table_remove(response->priv->headers, l_name);
+
     g_free(l_name);
     return removed;
 }
@@ -70,6 +71,13 @@ balde_response_append_body_len(balde_response_t *response, const gchar *content,
     const gssize len)
 {
     g_string_append_len(response->priv->body, content, len);
+}
+
+
+BALDE_API void
+balde_response_truncate_body(balde_response_t *response)
+{
+    g_string_truncate(response->priv->body, 0);
 }
 
 

--- a/src/responses.c
+++ b/src/responses.c
@@ -36,6 +36,28 @@ balde_response_set_header(balde_response_t *response, const gchar *name,
 }
 
 
+BALDE_API gboolean
+balde_response_remove_header(balde_response_t *response, const gchar *name)
+{
+    gboolean removed;
+    gchar *l_name = g_ascii_strdown(name, -1);
+    removed = g_hash_table_remove(response->priv->headers, l_name);
+    g_free(l_name);
+    return removed;
+}
+
+
+BALDE_API GSList*
+balde_response_get_header(balde_response_t *response, const gchar *name)
+{
+    gchar *l_name = g_ascii_strdown(name, -1);
+    GSList *value = g_hash_table_lookup(response->priv->headers, l_name);
+
+    g_free(l_name);
+    return value;
+}
+
+
 BALDE_API void
 balde_response_append_body(balde_response_t *response, const gchar *content)
 {
@@ -232,6 +254,25 @@ gchar*
 balde_response_generate_etag(balde_response_t *response)
 {
     return g_compute_checksum_for_string(G_CHECKSUM_MD5, response->priv->body->str, response->priv->body->len);
+}
+
+
+void
+balde_response_add_etag_header(balde_response_t * response, gboolean weak)
+{
+    GString *header_contents = g_string_new("");
+    if (weak) {
+        g_string_append(header_contents, "W/");
+    }
+    g_string_append(header_contents, "\"");
+    gchar *hash = balde_response_generate_etag(response);
+    g_string_append(header_contents, hash);
+    g_string_append(header_contents, "\"");
+    balde_response_remove_header(response, BALDE_RESPONSE_ETAG_HEADER);
+    balde_response_set_header(response, BALDE_RESPONSE_ETAG_HEADER, header_contents->str);
+
+    g_string_free(header_contents, TRUE);
+    g_free(hash);
 }
 
 

--- a/src/responses.h
+++ b/src/responses.h
@@ -31,6 +31,8 @@ gboolean balde_response_remove_header(balde_response_t *response,
 gchar* balde_response_generate_etag(balde_response_t *response, gboolean weak);
 void balde_response_add_etag_header(balde_response_t * response,
     gboolean weak);
+void balde_response_etag_matching(balde_request_t *request,
+    balde_response_t *response);
 GString* balde_response_render(balde_response_t *response,
     const gboolean with_body);
 void balde_response_print(GString *response);

--- a/src/responses.h
+++ b/src/responses.h
@@ -28,7 +28,7 @@ void balde_fix_header_name(gchar *name);
 void balde_header_render(const gchar *key, GSList *value, GString *str);
 gboolean balde_response_remove_header(balde_response_t *response,
     const gchar *name);
-gchar* balde_response_generate_etag(balde_response_t *response);
+gchar* balde_response_generate_etag(balde_response_t *response, gboolean weak);
 void balde_response_add_etag_header(balde_response_t * response,
     gboolean weak);
 GString* balde_response_render(balde_response_t *response,

--- a/src/responses.h
+++ b/src/responses.h
@@ -12,6 +12,8 @@
 #include <glib.h>
 #include "balde.h"
 
+static const gchar *BALDE_RESPONSE_ETAG_HEADER = "ETag";
+
 struct _balde_response_private_t {
     GHashTable *headers;
     GHashTable *template_ctx;
@@ -24,7 +26,11 @@ balde_response_t* balde_make_response_from_gstring(GString *content);
 balde_response_t* balde_make_response_from_exception(GError *error);
 void balde_fix_header_name(gchar *name);
 void balde_header_render(const gchar *key, GSList *value, GString *str);
+gboolean balde_response_remove_header(balde_response_t *response,
+    const gchar *name);
 gchar* balde_response_generate_etag(balde_response_t *response);
+void balde_response_add_etag_header(balde_response_t * response,
+    gboolean weak);
 GString* balde_response_render(balde_response_t *response,
     const gboolean with_body);
 void balde_response_print(GString *response);

--- a/src/responses.h
+++ b/src/responses.h
@@ -24,6 +24,7 @@ balde_response_t* balde_make_response_from_gstring(GString *content);
 balde_response_t* balde_make_response_from_exception(GError *error);
 void balde_fix_header_name(gchar *name);
 void balde_header_render(const gchar *key, GSList *value, GString *str);
+gchar* balde_response_generate_etag(balde_response_t *response);
 GString* balde_response_render(balde_response_t *response,
     const gboolean with_body);
 void balde_response_print(GString *response);

--- a/src/scgi.c
+++ b/src/scgi.c
@@ -18,6 +18,7 @@
 #include "cgi.h"
 #include "exceptions.h"
 #include "requests.h"
+#include "utils.h"
 #include "scgi.h"
 
 
@@ -151,8 +152,8 @@ balde_scgi_parse_request(balde_app_t *app, GInputStream *istream)
     }
 
     GString *body = NULL;
-    GHashTable *headers = g_hash_table_new_full(g_str_hash, g_str_equal,
-        g_free, g_free);
+    GHashTable *headers = g_hash_table_new_full(g_str_hash,
+        balde_header_compare, g_free, g_free);
 
     g_hash_table_foreach(env, (GHFunc) balde_filter_headers, headers);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -130,3 +130,12 @@ balde_constant_time_compare(const gchar *v1, const gchar *v2)
         rv |= left[i] ^ _v2[i];
     return rv == 0;
 }
+
+
+/*
+ * Function used to compare case-insensitive keys inside a hashtable
+ */
+gboolean balde_header_compare(gconstpointer a, gconstpointer b)
+{
+    return g_ascii_strcasecmp((gchar *) a, (gchar *) b) == 0;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -135,7 +135,8 @@ balde_constant_time_compare(const gchar *v1, const gchar *v2)
 /*
  * Function used to compare case-insensitive keys inside a hashtable
  */
-gboolean balde_header_compare(gconstpointer a, gconstpointer b)
+gboolean
+balde_header_compare(gconstpointer a, gconstpointer b)
 {
     return g_ascii_strcasecmp((gchar *) a, (gchar *) b) == 0;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,5 +20,6 @@ gint64 balde_timestamp(void);
 gchar* balde_encoded_timestamp(void);
 gboolean balde_validate_timestamp(const gchar* timestamp, gint64 max_delta);
 gboolean balde_constant_time_compare(const gchar *v1, const gchar *v2);
+gboolean balde_header_compare(gconstpointer a, gconstpointer b);
 
 #endif /* _BALDE_UTILS_PRIVATE_H */

--- a/tests/check_requests.c
+++ b/tests/check_requests.c
@@ -14,6 +14,7 @@
 #include <glib/gstdio.h>
 #include "../src/balde.h"
 #include "../src/app.h"
+#include "../src/utils.h"
 #include "utils.h"
 
 
@@ -170,7 +171,7 @@ test_make_request_with_env(void)
     env->path_info = g_strdup("/");
     env->request_method = g_strdup("GET");
     env->query_string = g_strdup("asd=lol&xd=hehe");
-    env->headers = g_hash_table_new_full(g_str_hash, g_str_equal,
+    env->headers = g_hash_table_new_full(g_str_hash, balde_header_compare,
         g_free, g_free);
     g_hash_table_replace(env->headers, g_strdup("lol-hehe"), g_strdup("12345"));
     g_hash_table_replace(env->headers, g_strdup("xd"), g_strdup("asdf"));
@@ -205,8 +206,8 @@ test_make_request_with_body(void)
     env->path_info = g_strdup("/");
     env->request_method = g_strdup("POST");
     env->query_string = g_strdup("asd=lol&xd=hehe");
-    env->headers = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
-        g_free);
+    env->headers = g_hash_table_new_full(g_str_hash, balde_header_compare,
+        g_free, g_free);
     g_hash_table_replace(env->headers, g_strdup("content-type"),
         g_strdup(
             "multipart/form-data; boundary=---------------------------"

--- a/tests/check_resources.c
+++ b/tests/check_resources.c
@@ -104,7 +104,7 @@ test_make_response_from_static_resource(void)
     g_assert(g_str_has_suffix(tmp->data, " GMT"));
     tmp = g_hash_table_lookup(response->priv->headers, "etag");
     g_assert_cmpstr(tmp->data, ==,
-        "\"balde-daab60b9178fd56656840a7fb9fc491c-48536785a0d37e65c9ebc6d7ee25119a\"");
+        "W/\"48536785a0d37e65c9ebc6d7ee25119a\"");
     tmp = g_hash_table_lookup(response->priv->headers, "content-type");
     g_assert_cmpstr(tmp->data, ==, "text/css");
     g_assert_cmpstr(response->priv->body->str, ==,
@@ -121,7 +121,7 @@ void
 test_make_response_from_static_resource_304(void)
 {
     g_setenv("HTTP_IF_NONE_MATCH",
-        "\"balde-daab60b9178fd56656840a7fb9fc491c-48536785a0d37e65c9ebc6d7ee25119a\"",
+        "W/\"48536785a0d37e65c9ebc6d7ee25119a\"",
         TRUE);
     balde_app_t *app = balde_app_init();
     balde_resources_load(app, resources_get_resource());
@@ -137,7 +137,7 @@ test_make_response_from_static_resource_304(void)
     g_assert(g_str_has_suffix(tmp->data, " GMT"));
     tmp = g_hash_table_lookup(response->priv->headers, "etag");
     g_assert_cmpstr(tmp->data, ==,
-        "\"balde-daab60b9178fd56656840a7fb9fc491c-48536785a0d37e65c9ebc6d7ee25119a\"");
+        "W/\"48536785a0d37e65c9ebc6d7ee25119a\"");
     tmp = g_hash_table_lookup(response->priv->headers, "content-type");
     g_assert_cmpstr(tmp->data, ==, "text/css");
     g_assert_cmpstr(response->priv->body->str, ==, "");

--- a/tests/check_responses.c
+++ b/tests/check_responses.c
@@ -291,8 +291,10 @@ void test_balde_response_generate_etag(void)
 {
     gchar* hash;
     balde_response_t *res = balde_make_response("quico");
-    hash = balde_response_generate_etag(res);
-    g_assert_cmpstr("15929f6ea6e9a8e093b05cf723d1e424", ==, hash);
+    hash = balde_response_generate_etag(res, FALSE);
+    g_assert_cmpstr("\"15929f6ea6e9a8e093b05cf723d1e424\"", ==, hash);
+    hash = balde_response_generate_etag(res, TRUE);
+    g_assert_cmpstr("W/\"15929f6ea6e9a8e093b05cf723d1e424\"", ==, hash);
     g_free(hash);
     balde_response_free(res);
 }

--- a/tests/check_responses.c
+++ b/tests/check_responses.c
@@ -286,6 +286,7 @@ test_response_render(void)
     balde_response_free(res);
 }
 
+
 void test_balde_response_generate_etag(void)
 {
     gchar* hash;
@@ -293,6 +294,27 @@ void test_balde_response_generate_etag(void)
     hash = balde_response_generate_etag(res);
     g_assert_cmpstr("15929f6ea6e9a8e093b05cf723d1e424", ==, hash);
     g_free(hash);
+}
+
+
+void test_balde_response_add_etag(void)
+{
+    GSList* generated_etag;
+    gchar* etag_value;
+
+    balde_response_t *res = balde_make_response("quico");
+
+    balde_response_add_etag_header(res, FALSE);
+    generated_etag = balde_response_get_header(res, BALDE_RESPONSE_ETAG_HEADER);
+    etag_value = (gchar *) generated_etag->data;
+
+    g_assert_cmpstr("\"15929f6ea6e9a8e093b05cf723d1e424\"", ==, etag_value);
+
+    balde_response_add_etag_header(res, TRUE);
+    generated_etag = balde_response_get_header(res, BALDE_RESPONSE_ETAG_HEADER);
+    etag_value = (gchar *) generated_etag->data;
+
+    g_assert_cmpstr("W/\"15929f6ea6e9a8e093b05cf723d1e424\"", ==, etag_value);
 }
 
 
@@ -420,6 +442,7 @@ main(int argc, char** argv)
         test_response_set_cookie_with_secure_and_httponly);
     g_test_add_func("/responses/delete_cookie", test_response_delete_cookie);
     g_test_add_func("/responses/generate_etag", test_balde_response_generate_etag);
+    g_test_add_func("/responses/add_etag", test_balde_response_add_etag);
     g_test_add_func("/responses/render", test_response_render);
     g_test_add_func("/responses/render_with_custom_mime_type",
         test_response_render_with_custom_mime_type);

--- a/tests/check_responses.c
+++ b/tests/check_responses.c
@@ -321,6 +321,7 @@ void test_balde_response_add_etag(void)
     balde_response_free(res);
 }
 
+
 void test_balde_response_etag_matching(void)
 {
     g_setenv("HTTP_IF_NONE_MATCH", "\"15929f6ea6e9a8e093b05cf723d1e424\"",

--- a/tests/check_responses.c
+++ b/tests/check_responses.c
@@ -294,6 +294,7 @@ void test_balde_response_generate_etag(void)
     hash = balde_response_generate_etag(res);
     g_assert_cmpstr("15929f6ea6e9a8e093b05cf723d1e424", ==, hash);
     g_free(hash);
+    balde_response_free(res);
 }
 
 

--- a/tests/check_responses.c
+++ b/tests/check_responses.c
@@ -315,6 +315,15 @@ void test_balde_response_add_etag(void)
     etag_value = (gchar *) generated_etag->data;
 
     g_assert_cmpstr("W/\"15929f6ea6e9a8e093b05cf723d1e424\"", ==, etag_value);
+    balde_response_free(res);
+}
+
+
+void test_balde_response_truncate_body(void)
+{
+    balde_response_t *res = balde_make_response("quico");
+    balde_response_truncate_body(res);
+    g_assert_cmpstr("", ==, res->priv->body->str);
 }
 
 
@@ -441,8 +450,11 @@ main(int argc, char** argv)
     g_test_add_func("/responses/set_cookie_with_secure_and_httponly",
         test_response_set_cookie_with_secure_and_httponly);
     g_test_add_func("/responses/delete_cookie", test_response_delete_cookie);
-    g_test_add_func("/responses/generate_etag", test_balde_response_generate_etag);
+    g_test_add_func("/responses/generate_etag",
+        test_balde_response_generate_etag);
     g_test_add_func("/responses/add_etag", test_balde_response_add_etag);
+    g_test_add_func("/responses/truncate_body",
+        test_balde_response_truncate_body);
     g_test_add_func("/responses/render", test_response_render);
     g_test_add_func("/responses/render_with_custom_mime_type",
         test_response_render_with_custom_mime_type);

--- a/tests/check_responses.c
+++ b/tests/check_responses.c
@@ -286,6 +286,15 @@ test_response_render(void)
     balde_response_free(res);
 }
 
+void test_balde_response_generate_etag(void)
+{
+    gchar* hash;
+    balde_response_t *res = balde_make_response("quico");
+    hash = balde_response_generate_etag(res);
+    g_assert_cmpstr("15929f6ea6e9a8e093b05cf723d1e424", ==, hash);
+    g_free(hash);
+}
+
 
 void
 test_response_render_with_custom_mime_type(void)
@@ -410,6 +419,7 @@ main(int argc, char** argv)
     g_test_add_func("/responses/set_cookie_with_secure_and_httponly",
         test_response_set_cookie_with_secure_and_httponly);
     g_test_add_func("/responses/delete_cookie", test_response_delete_cookie);
+    g_test_add_func("/responses/generate_etag", test_balde_response_generate_etag);
     g_test_add_func("/responses/render", test_response_render);
     g_test_add_func("/responses/render_with_custom_mime_type",
         test_response_render_with_custom_mime_type);


### PR DESCRIPTION
The basic idea is to user call `balde_response_etag_matching` after it has created the body, and if there is a `If-None-Match` header it will try to match the body hash with sent header, if it is ok, it will truncate the body and change the status code to 304 Not Modified.
If user wants to add a etag header to it's response, it should call `balde_response_add_etag_header`.

As I'm a c developer, you can nitpick the code :)