### PR TITLE
Development Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,26 @@
-# Development only docker, run with `docker run -it -v $(pwd):/balde balde make check`
-# in example.
-FROM balde/balde
-RUN apt-get update && apt-get install valgrind libglib2.0-0-dbg -y && apt-get clean
-WORKDIR /balde
+FROM debian:jessie
+MAINTAINER Sven Dowideit <SvenDowideit@home.org.au> @SvenDowideit
+
+# build using:
+#   docker build -t balde:dev .
+
+# then run:
+#   docker run -it balde:dev make check
+
+# or to run interactivly, editing your code outside the container:
+#   docker run -it -v $(pwd):/usr/src/balde balde:dev bash
+
+RUN apt-get update && apt-get install -yq \
+    pkg-config gettext zlib1g-dev libffi-dev \
+    autoconf automake build-essential libtool libxml2-utils \
+    libfcgi-dev shared-mime-info libglib2.0-dev wget peg ca-certificates \
+    valgrind libglib2.0-0-dbg \
+    --no-install-recommends && apt-get clean
+
+WORKDIR /usr/src/balde
+COPY . /usr/src/balde
+
+RUN ./autogen.sh && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install


### PR DESCRIPTION
The `balde/balde` image seems to be more for release tags, whereas this Dockerfile allows a developer to build without installing buildtools on their local host (and still allows the original workflow)

Additionally, you could set this up as an hub/cloud autobuild, thus gaining a rudimentary CI system, on merge/commit to master, hub would rebuild from the GH repository.
