### PR TITLE
Implement unix socket for fcgi server

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -202,10 +202,12 @@ libbalde_la_SOURCES = \
 libbalde_la_CFLAGS = \
 	-fvisibility=hidden \
 	$(AM_CFLAGS) \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 libbalde_la_LIBADD = \
-	$(GLIB_LIBS)
+	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS)
 
 libbalde_la_LDFLAGS = \
 	-version-info $(LIBBALDE_LT_VERSION_INFO)

--- a/Makefile.am
+++ b/Makefile.am
@@ -452,7 +452,8 @@ tests_check_app_SOURCES = \
 	tests/check_app.c
 
 tests_check_app_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_app_LDFLAGS = \
 	-static \
@@ -466,7 +467,8 @@ tests_check_datetime_SOURCES = \
 	tests/check_datetime.c
 
 tests_check_datetime_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_datetime_LDFLAGS = \
 	-static \
@@ -480,7 +482,8 @@ tests_check_exceptions_SOURCES = \
 	tests/check_exceptions.c
 
 tests_check_exceptions_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_exceptions_LDFLAGS = \
 	-static \
@@ -496,6 +499,7 @@ tests_check_multipart_SOURCES = \
 
 tests_check_multipart_CFLAGS = \
 	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS) \
 	-I$(top_srcdir)/tests
 
 tests_check_multipart_LDFLAGS = \
@@ -516,7 +520,8 @@ tests_check_quickstart_SOURCES = \
 	tests/check_quickstart.c
 
 tests_check_quickstart_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_quickstart_LDFLAGS = \
 	-static \
@@ -537,6 +542,7 @@ tests/tests_check_resources-check_resources.$(OBJEXT): tests/resources.c tests/r
 
 tests_check_resources_CFLAGS = \
 	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS) \
 	-I$(top_builddir)/tests
 
 tests_check_resources_LDFLAGS = \
@@ -545,13 +551,15 @@ tests_check_resources_LDFLAGS = \
 
 tests_check_resources_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_routing_SOURCES = \
 	tests/check_routing.c
 
 tests_check_routing_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_routing_LDFLAGS = \
 	-static \
@@ -565,7 +573,8 @@ tests_check_sapi_cgi_SOURCES = \
 	tests/check_sapi_cgi.c
 
 tests_check_sapi_cgi_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_sapi_cgi_LDFLAGS = \
 	-static \
@@ -573,6 +582,7 @@ tests_check_sapi_cgi_LDFLAGS = \
 
 tests_check_sapi_cgi_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_sapi_cgi_stdin_SOURCES = \
@@ -580,7 +590,8 @@ tests_check_sapi_cgi_stdin_SOURCES = \
 	tests/mock_sapi_cgi_stdin.c
 
 tests_check_sapi_cgi_stdin_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_sapi_cgi_stdin_LDFLAGS = \
 	-static \
@@ -588,6 +599,7 @@ tests_check_sapi_cgi_stdin_LDFLAGS = \
 
 tests_check_sapi_cgi_stdin_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_sapi_httpd_SOURCES = \
@@ -595,7 +607,8 @@ tests_check_sapi_httpd_SOURCES = \
 	tests/mock_sapi_httpd.c
 
 tests_check_sapi_httpd_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_sapi_httpd_LDFLAGS = \
 	-static \
@@ -603,13 +616,15 @@ tests_check_sapi_httpd_LDFLAGS = \
 
 tests_check_sapi_httpd_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_sapi_scgi_SOURCES = \
 	tests/check_sapi_scgi.c
 
 tests_check_sapi_scgi_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_sapi_scgi_LDFLAGS = \
 	-static \
@@ -617,6 +632,7 @@ tests_check_sapi_scgi_LDFLAGS = \
 
 tests_check_sapi_scgi_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_sessions_SOURCES = \
@@ -624,7 +640,8 @@ tests_check_sessions_SOURCES = \
 	tests/mock_sessions.c
 
 tests_check_sessions_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_sessions_LDFLAGS = \
 	-static \
@@ -632,6 +649,7 @@ tests_check_sessions_LDFLAGS = \
 
 tests_check_sessions_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_template_SOURCES = \
@@ -640,6 +658,7 @@ tests_check_template_SOURCES = \
 
 tests_check_template_CFLAGS = \
 	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS) \
 	-I$(top_srcdir)/tests
 
 tests_check_template_LDFLAGS = \
@@ -648,6 +667,7 @@ tests_check_template_LDFLAGS = \
 
 tests_check_template_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la \
 	libbalde_template.la
 
@@ -676,7 +696,8 @@ tests_check_template_helpers_SOURCES = \
 	tests/check_template_helpers.c
 
 tests_check_template_helpers_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_template_helpers_LDFLAGS = \
 	-static \
@@ -684,6 +705,7 @@ tests_check_template_helpers_LDFLAGS = \
 
 tests_check_template_helpers_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_utils_SOURCES = \
@@ -691,7 +713,8 @@ tests_check_utils_SOURCES = \
 	tests/mock_utils.c
 
 tests_check_utils_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_utils_LDFLAGS = \
 	-static \
@@ -699,6 +722,7 @@ tests_check_utils_LDFLAGS = \
 
 tests_check_utils_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_requests_SOURCES = \
@@ -707,6 +731,7 @@ tests_check_requests_SOURCES = \
 
 tests_check_requests_CFLAGS = \
 	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS) \
 	-I$(top_srcdir)/tests
 
 tests_check_requests_LDFLAGS = \
@@ -715,6 +740,7 @@ tests_check_requests_LDFLAGS = \
 
 tests_check_requests_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests_check_responses_SOURCES = \
@@ -722,7 +748,8 @@ tests_check_responses_SOURCES = \
 	tests/mock_responses.c
 
 tests_check_responses_CFLAGS = \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(GIO_UNIX_CFLAGS)
 
 tests_check_responses_LDFLAGS = \
 	-static \
@@ -730,6 +757,7 @@ tests_check_responses_LDFLAGS = \
 
 tests_check_responses_LDADD = \
 	$(GLIB_LIBS) \
+	$(GIO_UNIX_LIBS) \
 	libbalde.la
 
 tests/resources.c: tests/resources.xml $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies --sourcedir $(top_srcdir)/tests/static $(top_srcdir)/tests/resources.xml)

--- a/configure.ac
+++ b/configure.ac
@@ -110,14 +110,14 @@ AC_SUBST(LEG)
 
 # we need to make sure that shared-mime-info is installed, because we need it
 # for accurate mime-type guess
-GLIB_DEP="glib-2.0 >= 2.35, gio-2.0 >= 2.35, shared-mime-info"
+GLIB_DEP="glib-2.0 >= 2.35, gio-2.0 >= 2.35, gio-unix-2.0 >= 2.35, shared-mime-info"
 PC_DEPS="${GLIB_DEP}"
 AC_SUBST(PC_DEPS)
 
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([GLIB], [$GLIB_DEP])
 
-GLIB_COMPILE_RESOURCES="`$PKG_CONFIG --variable glib_compile_resources gio-2.0`"
+GLIB_COMPILE_RESOURCES="`$PKG_CONFIG --variable glib_compile_resources gio-2.0 gio-unix-2.0`"
 AC_SUBST(GLIB_COMPILE_RESOURCES)
 
 AC_CHECK_HEADERS([sys/types.h sys/stat.h])

--- a/configure.ac
+++ b/configure.ac
@@ -108,16 +108,27 @@ AM_CONDITIONAL([USE_LEG], [test "x$have_leg" = "xyes"])
 LEG="$ac_cv_path_leg"
 AC_SUBST(LEG)
 
+AC_ARG_ENABLE([unix-socket], AS_HELP_STRING([--disable-unix-socket], [disable unix-socket support]))
+
+AS_IF([test "x$enable_unix_socket" != "xno"], [
+  PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0 >= 2.35],
+    AC_DEFINE([WITH_UNIX_SOCKETS], [1], [Unix socket support is enabled])
+  )
+  UNIX_SOCKET=enabled
+], [
+  UNIX_SOCKET=disabled
+])
+
 # we need to make sure that shared-mime-info is installed, because we need it
 # for accurate mime-type guess
-GLIB_DEP="glib-2.0 >= 2.35, gio-2.0 >= 2.35, gio-unix-2.0 >= 2.35, shared-mime-info"
+GLIB_DEP="glib-2.0 >= 2.35, gio-2.0 >= 2.35, shared-mime-info"
 PC_DEPS="${GLIB_DEP}"
 AC_SUBST(PC_DEPS)
 
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([GLIB], [$GLIB_DEP])
 
-GLIB_COMPILE_RESOURCES="`$PKG_CONFIG --variable glib_compile_resources gio-2.0 gio-unix-2.0`"
+GLIB_COMPILE_RESOURCES="`$PKG_CONFIG --variable glib_compile_resources gio-2.0`"
 AC_SUBST(GLIB_COMPILE_RESOURCES)
 
 AC_CHECK_HEADERS([sys/types.h sys/stat.h])
@@ -140,6 +151,7 @@ AS_ECHO("
         compiler:     ${CC}
         cflags:       ${CFLAGS}
         ldflags:      ${LDFLAGS}
+        unix socket:  ${UNIX_SOCKET}
 
         examples:     ${EXAMPLES}
 

--- a/src/balde.h
+++ b/src/balde.h
@@ -11,7 +11,9 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#ifdef WITH_UNIX_SOCKETS
 #include <gio/gunixsocketaddress.h>
+#endif
 
 
 /**

--- a/src/balde.h
+++ b/src/balde.h
@@ -11,6 +11,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <gio/gunixsocketaddress.h>
 
 
 /**

--- a/src/sapi/fcgi.c
+++ b/src/sapi/fcgi.c
@@ -604,8 +604,10 @@ static GOptionEntry entries_fcgi[] =
         "Embedded FastCGI server host. (default: 127.0.0.1)", "HOST"},
     {"fcgi-port", 0, 0, G_OPTION_ARG_INT, &port,
         "Embedded FastCGI server port. (default: 9000)", "PORT"},
+    #ifdef WITH_UNIX_SOCKETS
     {"fcgi-socket", 0, 0, G_OPTION_ARG_STRING, &socket,
         "Embedded FastCGI server unix socket.", "SOCKET"},
+    #endif
     {"fcgi-max-threads-server", 0, 0, G_OPTION_ARG_INT, &max_threads_server,
         "Embedded FastCGI max server threads. (default: 10)", "THREADS"},
     {"fcgi-max-threads-app", 0, 0, G_OPTION_ARG_INT, &max_threads_app,
@@ -655,12 +657,16 @@ balde_sapi_fcgi_run(balde_app_t *app)
     GSocketService *service = g_threaded_socket_service_new(max_threads_server);
     GSocketAddress *address = NULL;
     GSocketProtocol protocol = G_SOCKET_PROTOCOL_TCP;
+    #ifdef WITH_UNIX_SOCKETS
     if (socket == NULL)
         address = g_inet_socket_address_new_from_string(final_host, port);
     else {
         address = g_unix_socket_address_new(socket);
         protocol = G_SOCKET_PROTOCOL_DEFAULT;
     }
+    #else
+        address = g_inet_socket_address_new_from_string(final_host, port);
+    #endif
 
     g_socket_listener_add_address(G_SOCKET_LISTENER(service), address,
         G_SOCKET_TYPE_STREAM, protocol, NULL, NULL, &error);

--- a/src/sapi/fcgi.c
+++ b/src/sapi/fcgi.c
@@ -591,6 +591,7 @@ cleanup:
 
 static gboolean runfcgi = FALSE;
 static gchar *host = NULL;
+static gchar *socket = NULL;
 static gint port = 9000;
 static gint max_threads_server = 10;
 static gint max_threads_app = 10;
@@ -603,6 +604,8 @@ static GOptionEntry entries_fcgi[] =
         "Embedded FastCGI server host. (default: 127.0.0.1)", "HOST"},
     {"fcgi-port", 0, 0, G_OPTION_ARG_INT, &port,
         "Embedded FastCGI server port. (default: 9000)", "PORT"},
+    {"fcgi-socket", 0, 0, G_OPTION_ARG_STRING, &socket,
+        "Embedded FastCGI server unix socket.", "SOCKET"},
     {"fcgi-max-threads-server", 0, 0, G_OPTION_ARG_INT, &max_threads_server,
         "Embedded FastCGI max server threads. (default: 10)", "THREADS"},
     {"fcgi-max-threads-app", 0, 0, G_OPTION_ARG_INT, &max_threads_app,
@@ -627,28 +630,46 @@ balde_sapi_fcgi_supported(void)
     return runfcgi;
 }
 
+void
+balde_cleanup_socket(gchar* socket, gboolean failed_to_run) {
+    if (socket == NULL || failed_to_run == TRUE)
+        return;
+    GFile* file = g_file_new_for_path(socket);
+    g_file_delete(file, NULL, NULL);
+    g_object_unref(file);
+}
 
 static gint
 balde_sapi_fcgi_run(balde_app_t *app)
 {
-    // TODO: add unix socket support
     GError *error = NULL;
     const gchar *final_host = host != NULL ? host : "127.0.0.1";
-    g_printerr(" * Running FastCGI on %s:%d (server threads: %d, app threads: %d)\n",
-        final_host, port, max_threads_server, max_threads_app);
+    if (socket == NULL)
+        g_printerr(" * Running FastCGI on %s:%d",
+            final_host, port);
+    else
+        g_printerr(" * Running FastCGI on socket %s", socket);
 
+    g_printerr(" (server threads: %d, app threads: %d)\n",
+        max_threads_server, max_threads_app);
     GSocketService *service = g_threaded_socket_service_new(max_threads_server);
-    GInetAddress* addr_host = g_inet_address_new_from_string(final_host);
-    GSocketAddress *address = g_inet_socket_address_new(addr_host, port);
+    GSocketAddress *address = NULL;
+    GSocketProtocol protocol = G_SOCKET_PROTOCOL_TCP;
+    if (socket == NULL)
+        address = g_inet_socket_address_new_from_string(final_host, port);
+    else {
+        address = g_unix_socket_address_new(socket);
+        protocol = G_SOCKET_PROTOCOL_DEFAULT;
+    }
 
     g_socket_listener_add_address(G_SOCKET_LISTENER(service), address,
-        G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_TCP, NULL, NULL, &error);
+        G_SOCKET_TYPE_STREAM, protocol, NULL, NULL, &error);
     if (error != NULL) {
         g_printerr("Failed to listen: %s\n", error->message);
         g_error_free(error);
         g_object_unref(service);
-        g_object_unref(addr_host);
         g_object_unref(address);
+        balde_cleanup_socket(socket, TRUE);
         g_free(host);
         return 3;
     }
@@ -661,8 +682,8 @@ balde_sapi_fcgi_run(balde_app_t *app)
         g_printerr("Failed to create app thread pool: %s\n", error->message);
         g_error_free(error);
         g_object_unref(service);
-        g_object_unref(addr_host);
         g_object_unref(address);
+        balde_cleanup_socket(socket, FALSE);
         g_free(host);
         g_free(ud);
         return 3;
@@ -671,13 +692,13 @@ balde_sapi_fcgi_run(balde_app_t *app)
     g_signal_connect(service, "run", G_CALLBACK(balde_incoming_callback), ud);
     g_socket_service_start(service);
     g_object_unref(service);
-    g_object_unref(addr_host);
     g_object_unref(address);
     GMainLoop *loop = g_main_loop_new(NULL, FALSE);
     g_main_loop_run(loop);
     g_thread_pool_free(ud->pool, TRUE, TRUE);
     g_free(ud);
     g_free(host);
+    balde_cleanup_socket(socket, FALSE);
     return 0;
 }
 

--- a/src/sapi/httpd.c
+++ b/src/sapi/httpd.c
@@ -258,7 +258,7 @@ balde_sapi_httpd_run(balde_app_t *app)
         g_free(host);
         return 3;
     }
-    g_signal_connect(service, "run", G_CALLBACK(balde_incoming_callback), app);
+    g_signal_connect(service, "incoming", G_CALLBACK(balde_incoming_callback), app);
     g_socket_service_start(service);
     g_object_unref(service);
     g_object_unref(addr_host);

--- a/src/sapi/httpd.c
+++ b/src/sapi/httpd.c
@@ -258,7 +258,7 @@ balde_sapi_httpd_run(balde_app_t *app)
         g_free(host);
         return 3;
     }
-    g_signal_connect(service, "incoming", G_CALLBACK(balde_incoming_callback), app);
+    g_signal_connect(service, "run", G_CALLBACK(balde_incoming_callback), app);
     g_socket_service_start(service);
     g_object_unref(service);
     g_object_unref(addr_host);


### PR DESCRIPTION
Hey there, here is a try to implement unix socket for fcgi server.
To make it work gio-unix is mandatory.
The function balde_cleanup_socket uses a boolean parameter to avoid
unlinking a file that didn't belong to it in case it fails to listen on
a specific socket.
Let me know if the patch makes sense and if something else needs do be
done.