### PR TITLE
docs: fix simple typo, reponse -> response

### DIFF
--- a/src/balde.h
+++ b/src/balde.h
@@ -449,7 +449,7 @@ void balde_response_set_etag_header(balde_response_t *response,
     gboolean weak);
 
 /**
- * Check if response matches a sent etag header and change reponse to be blank
+ * Check if response matches a sent etag header and change response to be blank
  * and change response code to 304 Not Modified.
  */
 void balde_response_etag_matching(balde_request_t *request,


### PR DESCRIPTION
There is a small typo in src/balde.h.

Should read `response` rather than `reponse`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md